### PR TITLE
Update casino menu and bank transfer flow

### DIFF
--- a/casino.py
+++ b/casino.py
@@ -3,89 +3,198 @@ import os
 import random
 import subprocess
 import sys
+import time
+
 import bank
 
-SAVE_FILE = 'casino_save.json'
+SAVE_FILE = "casino_save.json"
 
 
-def load_wallet():
+def load_wallet() -> int:
     if os.path.exists(SAVE_FILE):
-        with open(SAVE_FILE, 'r', encoding='utf-8') as f:
+        with open(SAVE_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
-        return data.get('wallet', 100)
+        return data.get("wallet", 100)
     return 100
 
 
-def save_wallet(wallet):
-    with open(SAVE_FILE, 'w', encoding='utf-8') as f:
-        json.dump({'wallet': wallet}, f, indent=2)
+def save_wallet(wallet: int) -> None:
+    with open(SAVE_FILE, "w", encoding="utf-8") as f:
+        json.dump({"wallet": wallet}, f, indent=2)
 
 
-def bank_menu(wallet):
-    user_id = 'player1'
+def one_or_two(wallet: int) -> int:
+    print("\n--- One or Two ---")
+    print(f"Wallet: {wallet}$")
+    if wallet <= 100:
+        print("Need at least 101$ to play.")
+        return wallet
     while True:
-        print(f"\n--- Bank ---\nWallet: {wallet}$")
-        action = input('(P) Pay, (R) Receive, (B) Back: ').strip().upper()
-        if action == 'P':
-            try:
-                amount = int(input('Amount to send: '))
-            except ValueError:
-                print('Invalid amount.')
-                continue
-            if amount <= 0 or amount > wallet:
-                print('Amount exceeds wallet.')
-                continue
-            wallet -= amount
-            save_wallet(wallet)
-            code = bank.create_transfer(user_id, amount, 'casino', 'fishing')
-            print(f'Transfer code: {code}')
-            print('Launching fishing game...')
-            subprocess.Popen([sys.executable, 'fishing.py'])
-            sys.exit(0)
-        elif action == 'R':
-            code = input('Enter code: ').strip().upper()
-            try:
-                amount = bank.claim_transfer(code, 'casino', user_id)
-            except Exception as e:
-                print(f'Error: {e}')
-                continue
-            wallet += amount
-            save_wallet(wallet)
-            print(f'Received {amount}$.')
-        elif action == 'B':
+        try:
+            bet = int(input("Bet amount (>100): "))
+        except ValueError:
+            print("Invalid amount.")
+            continue
+        if bet <= 100 or bet > wallet:
+            print("Bet must be >100 and ≤ wallet.")
+            continue
+        break
+    while True:
+        guess = input("Pick 1 or 2: ").strip()
+        if guess in ("1", "2"):
             break
-        else:
-            print('Invalid choice.')
+        print("Invalid choice. Enter 1 or 2.")
+    result = str(random.randint(1, 2))
+    wallet -= bet
+    if guess == result:
+        winnings = bet * 2
+        wallet += winnings
+        print(f"Number was {result}. You win {winnings}$!")
+    else:
+        print(f"Number was {result}. You lose {bet}$.")
+    save_wallet(wallet)
     return wallet
 
 
-def main():
+def clear_screen() -> None:
+    os.system("cls" if os.name == "nt" else "clear")
+
+
+def horse_race(wallet: int) -> int:
+    print("\n--- Horse Race ---")
+    print(f"Wallet: {wallet}$")
+    if wallet <= 100:
+        print("Need at least 101$ to play.")
+        return wallet
+    while True:
+        try:
+            bet = int(input("Bet amount (>100): "))
+        except ValueError:
+            print("Invalid amount.")
+            continue
+        if bet <= 100 or bet > wallet:
+            print("Bet must be >100 and ≤ wallet.")
+            continue
+        break
+    horses = ["A", "B", "C"]
+    while True:
+        pick = input("Choose your horse (A/B/C): ").strip().upper()
+        if pick in horses:
+            break
+        print("Invalid horse.")
+    positions = {h: 0 for h in horses}
+    finish = 20
+    while True:
+        clear_screen()
+        for h in horses:
+            track = "." * positions[h] + h
+            print(track)
+        time.sleep(0.2)
+        for h in horses:
+            positions[h] += random.randint(1, 3)
+        if max(positions.values()) >= finish:
+            break
+    winner = max(positions, key=positions.get)
+    print(f"Winner: {winner}")
+    wallet -= bet
+    if pick == winner:
+        winnings = bet * 2
+        wallet += winnings
+        print(f"Your horse won! You gain {winnings}$.")
+    else:
+        print(f"Your horse lost. You lose {bet}$.")
+    save_wallet(wallet)
+    return wallet
+
+
+def random_spin(wallet: int) -> int:
+    print("\n--- RANDOM ---")
+    print(f"Wallet: {wallet}$")
+    if wallet < 1000:
+        print("Need at least 1000$ for a spin.")
+        return wallet
+    wallet -= 1000
+    win = random.random() < 0.5
+    if win:
+        wallet += 2000
+        print("Paid 1000 -> Won 2000 (WIN)")
+    else:
+        print("Paid 1000 -> Won 0 (LOSE)")
+    save_wallet(wallet)
+    return wallet
+
+
+def bank_menu(wallet: int, user_id: str) -> int:
+    while True:
+        print(f"\n--- Bank ---\nWallet: {wallet}$")
+        print("(P) Pay to Fishing")
+        print("(R) Receive to Casino")
+        print("(Q) Back")
+        action = input("Choose: ").strip().upper()
+        if action == "P":
+            try:
+                amount = int(input("Amount to send: "))
+            except ValueError:
+                print("Invalid amount.")
+                continue
+            if amount <= 0 or amount > wallet:
+                print("Invalid amount.")
+                continue
+            wallet -= amount
+            save_wallet(wallet)
+            code = bank.create_transfer(user_id, amount, from_app="casino", to_app="fishing")
+            print(f"Transfer code: {code}")
+            print(f"New wallet: {wallet}$")
+            subprocess.Popen([sys.executable, "fishing.py"])
+            sys.exit(0)
+        elif action == "R":
+            code = input("Enter code: ").strip().upper()
+            try:
+                amount = bank.claim_transfer(code, expect_to_app="casino", user_id=user_id)
+            except Exception as e:
+                print(f"Error: {e}")
+                continue
+            wallet += amount
+            save_wallet(wallet)
+            print(f"Received {amount}$. Wallet: {wallet}$")
+        elif action == "Q":
+            break
+        else:
+            print("Invalid choice.")
+    return wallet
+
+
+def main() -> None:
     wallet = load_wallet()
+    user_id = "player1"
     while True:
         print(f"\n--- Casino ---\nWallet: {wallet}$")
-        print('1. Coin Flip (bet 10)')
-        print('2. Bank')
-        print('3. Exit')
-        choice = input('Choose: ').strip()
-        if choice == '1':
-            if wallet < 10:
-                print('Not enough money.')
-                continue
-            if random.random() < 0.5:
-                wallet += 10
-                print('You won 10!')
-            else:
-                wallet -= 10
-                print('You lost 10!')
+        print("  1) One or Two")
+        print("  2) Horse Race (ASCII)")
+        print("  3) RANDOM (1000$ spin)")
+        print("  4) Bank (Pay / Receive)")
+        print("  5) Return to Fishing")
+        print("  6) Exit")
+        choice = input("Choose: ").strip()
+        if choice == "1":
+            wallet = one_or_two(wallet)
+        elif choice == "2":
+            wallet = horse_race(wallet)
+        elif choice == "3":
+            wallet = random_spin(wallet)
+        elif choice == "4":
+            wallet = bank_menu(wallet, user_id)
+        elif choice == "5":
             save_wallet(wallet)
-        elif choice == '2':
-            wallet = bank_menu(wallet)
-        elif choice == '3':
+            subprocess.Popen([sys.executable, "fishing.py"])
+            sys.exit(0)
+        elif choice == "6":
             save_wallet(wallet)
             break
         else:
-            print('Invalid choice.')
+            print("Invalid choice.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
+

--- a/fishing.py
+++ b/fishing.py
@@ -1973,9 +1973,16 @@ class Game:
                 self.balance -= amount
                 self.save_game()
                 print(f"Transfer code: {code}")
-                print("Launching casino...")
-                subprocess.Popen([sys.executable, "casino.py"])
-                sys.exit(0)
+                while True:
+                    print("1) Return to main menu")
+                    print("2) Go to casino")
+                    choice = input("Choose: ").strip()
+                    if choice == "2":
+                        subprocess.Popen([sys.executable, "casino.py"])
+                        sys.exit(0)
+                    if choice == "1":
+                        return
+                    print("Invalid choice.")
             elif action == "R":
                 code = input("Enter receive code: ").strip().upper()
                 try:


### PR DESCRIPTION
## Summary
- Replace casino with new menu: One or Two, Horse Race, RANDOM spin, Bank, Return to Fishing, Exit
- Implement betting games with proper wallet handling and 100$+ limits
- Add bank submenu supporting pay/receive and returning to fishing
- After transferring funds from fishing, allow user to choose to return or launch casino

## Testing
- `python -m py_compile casino.py fishing.py`
- `python casino.py <<<"6"`


------
https://chatgpt.com/codex/tasks/task_e_689abdc441ec8331af69a247b0a49d29