### PR TITLE
Enable casino auto-claim from fishing

### DIFF
--- a/casino.py
+++ b/casino.py
@@ -165,8 +165,27 @@ def bank_menu(wallet: int, user_id: str) -> int:
 
 
 def main() -> None:
+    args = sys.argv[1:]
+    autoclaim_code = None
+    autoclaim_user = None
+    for i, arg in enumerate(args):
+        if arg == "--autoclaim" and i + 1 < len(args):
+            autoclaim_code = args[i + 1].upper()
+        elif arg == "--user" and i + 1 < len(args):
+            autoclaim_user = args[i + 1]
+
     wallet = load_wallet()
-    user_id = "player1"
+    user_id = autoclaim_user or "player1"
+
+    if autoclaim_code and autoclaim_user:
+        try:
+            amount = bank.claim_transfer(autoclaim_code, expect_to_app="casino", user_id=autoclaim_user)
+        except Exception as e:
+            print(f"Auto-claim failed: {e}")
+        else:
+            wallet += amount
+            save_wallet(wallet)
+            print(f"Auto-received ${amount} from Fishing.")
     while True:
         print(f"\n--- Casino ---\nWallet: {wallet}$")
         print("  1) One or Two")

--- a/fishing.py
+++ b/fishing.py
@@ -1978,7 +1978,7 @@ class Game:
                     print("2) Go to casino")
                     choice = input("Choose: ").strip()
                     if choice == "2":
-                        subprocess.Popen([sys.executable, "casino.py"])
+                        subprocess.Popen([sys.executable, "casino.py", "--autoclaim", code, "--user", user_id])
                         sys.exit(0)
                     if choice == "1":
                         return


### PR DESCRIPTION
## Summary
- Launch Casino with auto-claim parameters when paying from Fishing
- Parse `--autoclaim` handoff in Casino and claim transfer on startup

## Testing
- `python -m py_compile Powershell_fishing_game/fishing.py Powershell_fishing_game/casino.py`
- `python - <<'PY'
import bank, sys, subprocess, json, os
code = bank.create_transfer('player1', 50, 'fishing', 'casino')
print('code', code)
proc = subprocess.run([sys.executable, 'casino.py', '--autoclaim', code, '--user', 'player1'], input='6\n', text=True, capture_output=True)
print(proc.stdout)
print(proc.stderr)
with open('casino_save.json','r') as f:
    print('wallet saved:', json.load(f))
os.remove('casino_save.json')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689ad4978fdc8331b15c34dbc3223c50