### PR TITLE
Enable auto-claim bank transfers between games

### DIFF
--- a/bank.py
+++ b/bank.py
@@ -59,7 +59,8 @@ def create_transfer(user_id: str, amount: int, from_app: str, to_app: str) -> st
         }
         return code
 
-def claim_transfer(code: str, expect_to_app: str, user_id: str) -> int:
+def claim_transfer(code: str, expect_to_app: str, user_id: str) -> tuple[int, str]:
+    """Claim a transfer code and return the amount and originating app."""
     with _access_bank() as bank:
         t = bank['transfers'].get(code)
         if not t:
@@ -71,7 +72,7 @@ def claim_transfer(code: str, expect_to_app: str, user_id: str) -> int:
         if t['user_id'] != user_id:
             raise ValueError('User mismatch')
         t['claimed'] = True
-        return t['amount']
+        return t['amount'], t['from_app']
 
 def peek_transfer(code: str):
     with _lock:

--- a/casino.py
+++ b/casino.py
@@ -128,7 +128,6 @@ def bank_menu(wallet: int, user_id: str) -> int:
     while True:
         print(f"\n--- Bank ---\nWallet: {wallet}$")
         print("(P) Pay to Fishing")
-        print("(R) Receive to Casino")
         print("(Q) Back")
         action = input("Choose: ").strip().upper()
         if action == "P":
@@ -143,20 +142,8 @@ def bank_menu(wallet: int, user_id: str) -> int:
             wallet -= amount
             save_wallet(wallet)
             code = bank.create_transfer(user_id, amount, from_app="casino", to_app="fishing")
-            print(f"Transfer code: {code}")
-            print(f"New wallet: {wallet}$")
-            subprocess.Popen([sys.executable, "fishing.py"])
+            subprocess.Popen([sys.executable, "fishing.py", "--autoclaim", code, "--user", user_id])
             sys.exit(0)
-        elif action == "R":
-            code = input("Enter code: ").strip().upper()
-            try:
-                amount = bank.claim_transfer(code, expect_to_app="casino", user_id=user_id)
-            except Exception as e:
-                print(f"Error: {e}")
-                continue
-            wallet += amount
-            save_wallet(wallet)
-            print(f"Received {amount}$. Wallet: {wallet}$")
         elif action == "Q":
             break
         else:
@@ -179,19 +166,19 @@ def main() -> None:
 
     if autoclaim_code and autoclaim_user:
         try:
-            amount = bank.claim_transfer(autoclaim_code, expect_to_app="casino", user_id=autoclaim_user)
+            amount, from_app = bank.claim_transfer(autoclaim_code, expect_to_app="casino", user_id=autoclaim_user)
         except Exception as e:
             print(f"Auto-claim failed: {e}")
         else:
             wallet += amount
             save_wallet(wallet)
-            print(f"Auto-received ${amount} from Fishing.")
+            print(f"Auto-received ${amount} from {from_app}.")
     while True:
         print(f"\n--- Casino ---\nWallet: {wallet}$")
         print("  1) One or Two")
         print("  2) Horse Race (ASCII)")
         print("  3) RANDOM (1000$ spin)")
-        print("  4) Bank (Pay / Receive)")
+        print("  4) Bank (Pay)")
         print("  5) Return to Fishing")
         print("  6) Exit")
         choice = input("Choose: ").strip()

--- a/fishing.py
+++ b/fishing.py
@@ -1957,7 +1957,7 @@ class Game:
             clear_screen()
             print("--- Bank ---")
             print(f"Balance: {round(self.balance, 2)}$")
-            action = input("(P) Pay, (R) Receive, (B) Back: ").strip().upper()
+            action = input("(P) Pay, (B) Back: ").strip().upper()
             if action == "P":
                 try:
                     amount = int(input("Amount to send: "))
@@ -1972,7 +1972,6 @@ class Game:
                 code = bank.create_transfer(user_id, amount, "fishing", "casino")
                 self.balance -= amount
                 self.save_game()
-                print(f"Transfer code: {code}")
                 while True:
                     print("1) Return to main menu")
                     print("2) Go to casino")
@@ -1983,18 +1982,6 @@ class Game:
                     if choice == "1":
                         return
                     print("Invalid choice.")
-            elif action == "R":
-                code = input("Enter receive code: ").strip().upper()
-                try:
-                    amount = bank.claim_transfer(code, "fishing", user_id)
-                except Exception as e:
-                    print(f"Error: {e}")
-                    time.sleep(1)
-                    continue
-                self.balance += amount
-                self.save_game()
-                print(f"Received {amount}$")
-                input("Press Enter to continue...")
             elif action == "B":
                 break
             else:
@@ -2787,7 +2774,32 @@ class Game:
 # --------------------------- Main entry ---------------------------
 
 def main():
+    args = sys.argv[1:]
+    autoclaim_code = None
+    autoclaim_user = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--autoclaim" and i + 1 < len(args):
+            autoclaim_code = args[i + 1].upper()
+            i += 2
+        elif args[i] == "--user" and i + 1 < len(args):
+            autoclaim_user = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
     game = Game()
+
+    if autoclaim_code and autoclaim_user:
+        try:
+            amount, from_app = bank.claim_transfer(autoclaim_code, expect_to_app="fishing", user_id=autoclaim_user)
+        except Exception as e:
+            print(f"Auto-claim failed: {e}")
+        else:
+            game.balance += amount
+            game.save_game()
+            print(f"Auto-received ${amount} from {from_app}.")
+
     game.run()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Remove manual receive and transfer codes from both games' banks
- Launch target game immediately on pay and auto-claim balance via command-line handoff
- Add startup auto-claim processing and casino return option

## Testing
- `python -m py_compile Powershell_fishing_game/bank.py Powershell_fishing_game/casino.py Powershell_fishing_game/fishing.py`


------
https://chatgpt.com/codex/tasks/task_e_689adb62b29c8331b27fdc3d8177bbdb